### PR TITLE
[wip] Add new keyboard shortcuts

### DIFF
--- a/app/components/Icons.tsx
+++ b/app/components/Icons.tsx
@@ -328,6 +328,176 @@ export const ExclamationKey = () => {
   );
 };
 
+export const CtrlExclamationKey = () => {
+  return (
+    <svg
+      width="1em"
+      height="1em"
+      viewBox="0 0 100 100"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+    >
+      <rect
+        x="5"
+        y="12"
+        rx="10"
+        ry="10"
+        width="90"
+        height="76"
+        fill="transparent"
+        stroke="currentColor"
+        strokeWidth="5"
+      />
+      <text
+        x="50"
+        y="70"
+        textAnchor="middle"
+        fontSize="55"
+        fontWeight="bold"
+        textLength="75"
+      >
+        C-!
+      </text>
+    </svg>
+  );
+};
+
+export const AtSignKey = () => {
+  return (
+    <svg
+      width="1em"
+      height="1em"
+      viewBox="0 0 100 100"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+    >
+      <rect
+        x="5"
+        y="12"
+        rx="10"
+        ry="10"
+        width="90"
+        height="76"
+        fill="transparent"
+        stroke="currentColor"
+        strokeWidth="5"
+      />
+      <text
+        x="50"
+        y="77"
+        textAnchor="middle"
+        fontSize="80"
+        fontWeight="bold"
+        textLength="75"
+      >
+        @
+      </text>
+    </svg>
+  );
+};
+
+export const CtrlAtSignKey = () => {
+  return (
+    <svg
+      width="1em"
+      height="1em"
+      viewBox="0 0 100 100"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+    >
+      <rect
+        x="5"
+        y="12"
+        rx="10"
+        ry="10"
+        width="90"
+        height="76"
+        fill="transparent"
+        stroke="currentColor"
+        strokeWidth="5"
+      />
+      <text
+        x="50"
+        y="65"
+        textAnchor="middle"
+        fontSize="40"
+        fontWeight="bold"
+        textLength="75"
+      >
+        C-@
+      </text>
+    </svg>
+  );
+};
+
+export const HashKey = () => {
+  return (
+    <svg
+      width="1em"
+      height="1em"
+      viewBox="0 0 100 100"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+    >
+      <rect
+        x="5"
+        y="12"
+        rx="10"
+        ry="10"
+        width="90"
+        height="76"
+        fill="transparent"
+        stroke="currentColor"
+        strokeWidth="5"
+      />
+      <text
+        x="50"
+        y="77"
+        textAnchor="middle"
+        fontSize="80"
+        fontWeight="bold"
+        textLength="75"
+      >
+        #
+      </text>
+    </svg>
+  );
+};
+
+export const CtrlHashKey = () => {
+  return (
+    <svg
+      width="1em"
+      height="1em"
+      viewBox="0 0 100 100"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+    >
+      <rect
+        x="5"
+        y="12"
+        rx="10"
+        ry="10"
+        width="90"
+        height="76"
+        fill="transparent"
+        stroke="currentColor"
+        strokeWidth="5"
+      />
+      <text
+        x="50"
+        y="65"
+        textAnchor="middle"
+        fontSize="40"
+        fontWeight="bold"
+        textLength="75"
+      >
+        C-#
+      </text>
+    </svg>
+  );
+};
+
 const CheckOrReveal = ({
   x,
   y,

--- a/app/components/Icons.tsx
+++ b/app/components/Icons.tsx
@@ -156,14 +156,23 @@ export const Rebus = () => {
   );
 };
 
-export const EscapeKey = () => {
+const KeyIcon = (props: {
+  text: string;
+  width?: number;
+  stretchText?: boolean;
+  largeFont?: boolean;
+  className?: string;
+  textY?: number;
+}) => {
   return (
     <svg
-      width="1em"
+      width={props.width ? `${props.width}em` : '1em'}
       height="1em"
+      preserveAspectRatio="none"
       viewBox="0 0 100 100"
       xmlns="http://www.w3.org/2000/svg"
       fill="currentColor"
+      className={props.className}
     >
       <rect
         x="5"
@@ -178,325 +187,59 @@ export const EscapeKey = () => {
       />
       <text
         x="50"
-        y="70"
+        y={props.textY || 70}
         textAnchor="middle"
-        fontSize="60"
+        fontSize={props.largeFont ? 90 : 60}
         fontWeight="bold"
-        lengthAdjust="spacingAndGlyphs"
+        {...(props.stretchText && { lengthAdjust: 'spacingAndGlyphs' })}
         textLength="75"
       >
-        esc
+        {props.text}
       </text>
     </svg>
   );
 };
 
-export const EnterKey = () => {
-  return (
-    <svg
-      width="1em"
-      height="1em"
-      viewBox="0 0 100 100"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="currentColor"
-    >
-      <rect
-        x="5"
-        y="12"
-        rx="10"
-        ry="10"
-        width="90"
-        height="76"
-        fill="transparent"
-        stroke="currentColor"
-        strokeWidth="5"
-      />
-      <text
-        x="50"
-        y="70"
-        textAnchor="middle"
-        fontSize="60"
-        fontWeight="bold"
-        lengthAdjust="spacingAndGlyphs"
-        textLength="75"
-      >
-        enter
-      </text>
-    </svg>
-  );
-};
+export const EscapeKey = () => <KeyIcon text="esc" stretchText={true} />;
+export const EnterKey = () => (
+  <KeyIcon text="enter" width={1.5} stretchText={true} />
+);
 
-export const BacktickKey = () => {
-  return (
-    <svg
-      width="1em"
-      height="1em"
-      viewBox="0 0 100 100"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="currentColor"
-    >
-      <rect
-        x="5"
-        y="12"
-        rx="10"
-        ry="10"
-        width="90"
-        height="76"
-        fill="transparent"
-        stroke="currentColor"
-        strokeWidth="5"
-      />
-      <text
-        x="50"
-        y="95"
-        textAnchor="middle"
-        fontSize="90"
-        fontWeight="bold"
-        textLength="75"
-      >
-        `
-      </text>
-    </svg>
-  );
-};
+export const BacktickKey = () => (
+  <KeyIcon text="`" largeFont={true} textY={95} />
+);
+export const PeriodKey = () => <KeyIcon text="." largeFont={true} />;
+export const ExclamationKey = () => <KeyIcon text="!" />;
+export const HashKey = () => <KeyIcon text="#" />;
+export const AtSignKey = () => <KeyIcon text="@" />;
 
-export const PeriodKey = () => {
-  return (
-    <svg
-      width="1em"
-      height="1em"
-      viewBox="0 0 100 100"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="currentColor"
-    >
-      <rect
-        x="5"
-        y="12"
-        rx="10"
-        ry="10"
-        width="90"
-        height="76"
-        fill="transparent"
-        stroke="currentColor"
-        strokeWidth="5"
-      />
-      <text
-        x="50"
-        y="70"
-        textAnchor="middle"
-        fontSize="90"
-        fontWeight="bold"
-        textLength="75"
-      >
-        .
-      </text>
-    </svg>
-  );
-};
+const CtrlKey = () => (
+  <KeyIcon
+    text="ctrl"
+    stretchText={true}
+    width={1.1}
+    css={{ marginRight: '0.1em' }}
+  />
+);
 
-export const ExclamationKey = () => {
-  return (
-    <svg
-      width="1em"
-      height="1em"
-      viewBox="0 0 100 100"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="currentColor"
-    >
-      <rect
-        x="5"
-        y="12"
-        rx="10"
-        ry="10"
-        width="90"
-        height="76"
-        fill="transparent"
-        stroke="currentColor"
-        strokeWidth="5"
-      />
-      <text
-        x="50"
-        y="77"
-        textAnchor="middle"
-        fontSize="80"
-        fontWeight="bold"
-        textLength="75"
-      >
-        !
-      </text>
-    </svg>
-  );
-};
-
-export const CtrlExclamationKey = () => {
-  return (
-    <svg
-      width="1em"
-      height="1em"
-      viewBox="0 0 100 100"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="currentColor"
-    >
-      <rect
-        x="5"
-        y="12"
-        rx="10"
-        ry="10"
-        width="90"
-        height="76"
-        fill="transparent"
-        stroke="currentColor"
-        strokeWidth="5"
-      />
-      <text
-        x="50"
-        y="70"
-        textAnchor="middle"
-        fontSize="55"
-        fontWeight="bold"
-        textLength="75"
-      >
-        C-!
-      </text>
-    </svg>
-  );
-};
-
-export const AtSignKey = () => {
-  return (
-    <svg
-      width="1em"
-      height="1em"
-      viewBox="0 0 100 100"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="currentColor"
-    >
-      <rect
-        x="5"
-        y="12"
-        rx="10"
-        ry="10"
-        width="90"
-        height="76"
-        fill="transparent"
-        stroke="currentColor"
-        strokeWidth="5"
-      />
-      <text
-        x="50"
-        y="77"
-        textAnchor="middle"
-        fontSize="80"
-        fontWeight="bold"
-        textLength="75"
-      >
-        @
-      </text>
-    </svg>
-  );
-};
-
-export const CtrlAtSignKey = () => {
-  return (
-    <svg
-      width="1em"
-      height="1em"
-      viewBox="0 0 100 100"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="currentColor"
-    >
-      <rect
-        x="5"
-        y="12"
-        rx="10"
-        ry="10"
-        width="90"
-        height="76"
-        fill="transparent"
-        stroke="currentColor"
-        strokeWidth="5"
-      />
-      <text
-        x="50"
-        y="65"
-        textAnchor="middle"
-        fontSize="40"
-        fontWeight="bold"
-        textLength="75"
-      >
-        C-@
-      </text>
-    </svg>
-  );
-};
-
-export const HashKey = () => {
-  return (
-    <svg
-      width="1em"
-      height="1em"
-      viewBox="0 0 100 100"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="currentColor"
-    >
-      <rect
-        x="5"
-        y="12"
-        rx="10"
-        ry="10"
-        width="90"
-        height="76"
-        fill="transparent"
-        stroke="currentColor"
-        strokeWidth="5"
-      />
-      <text
-        x="50"
-        y="77"
-        textAnchor="middle"
-        fontSize="80"
-        fontWeight="bold"
-        textLength="75"
-      >
-        #
-      </text>
-    </svg>
-  );
-};
-
-export const CtrlHashKey = () => {
-  return (
-    <svg
-      width="1em"
-      height="1em"
-      viewBox="0 0 100 100"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="currentColor"
-    >
-      <rect
-        x="5"
-        y="12"
-        rx="10"
-        ry="10"
-        width="90"
-        height="76"
-        fill="transparent"
-        stroke="currentColor"
-        strokeWidth="5"
-      />
-      <text
-        x="50"
-        y="65"
-        textAnchor="middle"
-        fontSize="40"
-        fontWeight="bold"
-        textLength="75"
-      >
-        C-#
-      </text>
-    </svg>
-  );
-};
+export const CtrlHashKey = () => (
+  <>
+    <CtrlKey />
+    <HashKey />
+  </>
+);
+export const CtrlExclamationKey = () => (
+  <>
+    <CtrlKey />
+    <ExclamationKey />
+  </>
+);
+export const CtrlAtSignKey = () => (
+  <>
+    <CtrlKey />
+    <AtSignKey />
+  </>
+);
 
 const CheckOrReveal = ({
   x,

--- a/app/components/Puzzle.tsx
+++ b/app/components/Puzzle.tsx
@@ -44,6 +44,12 @@ import {
   RevealPuzzle,
   Rebus,
   SpinnerFinished,
+  CtrlExclamationKey,
+  CtrlAtSignKey,
+  CtrlHashKey,
+  ExclamationKey,
+  AtSignKey,
+  HashKey,
 } from './Icons';
 import { AuthContext, AuthPropsOptional } from './AuthContext';
 import { CrosshareAudioContext } from './CrosshareAudioContext';
@@ -535,6 +541,72 @@ export const Puzzle = ({
 
       const mkey = fromKeyboardEvent(e);
       if (isSome(mkey)) {
+        const key = mkey.value;
+        /* TODO this logic belongs in the reducer */
+        if (key.k === KeyK.Pause) {
+          const t = state.success ? 'UNDISMISSSUCCESS' : 'PAUSEACTION';
+          dispatch({ type: t });
+          writePlayToDBIfNeeded();
+          e.preventDefault();
+          return;
+        }
+        if (key.k === KeyK.Exclamation) {
+          const ca: CheatAction = {
+            type: 'CHEAT',
+            unit: CheatUnit.Square,
+          };
+          dispatch(ca);
+          e.preventDefault();
+          return;
+        }
+        if (key.k === KeyK.CtrlExclamation) {
+          const ca: CheatAction = {
+            type: 'CHEAT',
+            unit: CheatUnit.Square,
+            isReveal: true,
+          };
+          dispatch(ca);
+          e.preventDefault();
+          return;
+        }
+        if (key.k === KeyK.AtSign) {
+          const ca: CheatAction = {
+            type: 'CHEAT',
+            unit: CheatUnit.Entry,
+          };
+          dispatch(ca);
+          e.preventDefault();
+          return;
+        }
+        if (key.k === KeyK.CtrlAtSign) {
+          const ca: CheatAction = {
+            type: 'CHEAT',
+            unit: CheatUnit.Entry,
+            isReveal: true,
+          };
+          dispatch(ca);
+          e.preventDefault();
+          return;
+        }
+        if (key.k === KeyK.Hash) {
+          const ca: CheatAction = {
+            type: 'CHEAT',
+            unit: CheatUnit.Puzzle,
+          };
+          dispatch(ca);
+          e.preventDefault();
+          return;
+        }
+        if (key.k === KeyK.CtrlHash) {
+          const ca: CheatAction = {
+            type: 'CHEAT',
+            unit: CheatUnit.Puzzle,
+            isReveal: true,
+          };
+          dispatch(ca);
+          e.preventDefault();
+          return;
+        }
         const kpa: KeypressAction = { type: 'KEYPRESS', key: mkey.value };
         dispatch(kpa);
         e.preventDefault();
@@ -542,6 +614,7 @@ export const Puzzle = ({
     },
     [
       dispatch,
+      writePlayToDBIfNeeded,
       loadingPlayState,
       state.currentTimeWindowStart,
       state.success,
@@ -813,6 +886,7 @@ export const Puzzle = ({
               <TopBarDropDownLink
                 icon={<RevealSquare />}
                 text={t`Reveal Square`}
+                shortcutHint={<CtrlExclamationKey />}
                 onClick={() => {
                   const ca: CheatAction = {
                     type: 'CHEAT',
@@ -825,6 +899,7 @@ export const Puzzle = ({
               <TopBarDropDownLink
                 icon={<RevealEntry />}
                 text={t`Reveal Word`}
+                shortcutHint={<CtrlAtSignKey />}
                 onClick={() => {
                   const ca: CheatAction = {
                     type: 'CHEAT',
@@ -837,6 +912,7 @@ export const Puzzle = ({
               <TopBarDropDownLink
                 icon={<RevealPuzzle />}
                 text={t`Reveal Puzzle`}
+                shortcutHint={<CtrlHashKey />}
                 onClick={() => {
                   const ca: CheatAction = {
                     type: 'CHEAT',
@@ -866,6 +942,7 @@ export const Puzzle = ({
                 <TopBarDropDownLink
                   icon={<CheckSquare />}
                   text={t`Check Square`}
+                  shortcutHint={<ExclamationKey />}
                   onClick={() => {
                     const ca: CheatAction = {
                       type: 'CHEAT',
@@ -877,6 +954,7 @@ export const Puzzle = ({
                 <TopBarDropDownLink
                   icon={<CheckEntry />}
                   text={t`Check Word`}
+                  shortcutHint={<AtSignKey />}
                   onClick={() => {
                     const ca: CheatAction = {
                       type: 'CHEAT',
@@ -888,6 +966,7 @@ export const Puzzle = ({
                 <TopBarDropDownLink
                   icon={<CheckPuzzle />}
                   text={t`Check Puzzle`}
+                  shortcutHint={<HashKey />}
                   onClick={() => {
                     const ca: CheatAction = {
                       type: 'CHEAT',

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -279,6 +279,12 @@ export enum KeyK {
   Backtick,
   Dot,
   Exclamation,
+  AtSign,
+  Hash,
+  CtrlExclamation,
+  CtrlAtSign,
+  CtrlHash,
+  Pause,
   AllowedCharacter,
   // Keys specific to on-screen keyboard
   NumLayout,
@@ -296,10 +302,10 @@ export enum KeyK {
 export const ALLOWABLE_GRID_CHARS = /^[A-Za-z0-9Ññ&]$/;
 
 export function fromKeyString(string: string): Option<Key> {
-  return fromKeyboardEvent({ key: string, shiftKey: false });
+  return fromKeyboardEvent({ key: string });
 }
 
-export function fromKeyboardEvent(event: { key: string, shiftKey: boolean }): Option<Key> {
+export function fromKeyboardEvent(event: { key: string, shiftKey?: boolean, ctrlKey?: boolean }): Option<Key> {
   const basicKey: Option<Exclude<KeyK, KeyK.AllowedCharacter>> = (() => {
     switch (event.key) {
     case 'ArrowLeft': return some(KeyK.ArrowLeft);
@@ -316,7 +322,16 @@ export function fromKeyboardEvent(event: { key: string, shiftKey: boolean }): Op
     case 'Escape': return some(KeyK.Escape);
     case '`': return some(KeyK.Backtick);
     case '.': return some(KeyK.Dot);
-    case '!': return some(KeyK.Exclamation);
+    case '!': return !event.ctrlKey
+      ? some(KeyK.Exclamation)
+      : some(KeyK.CtrlExclamation);
+    case '@': return !event.ctrlKey
+      ? some(KeyK.AtSign)
+      : some(KeyK.CtrlAtSign);
+    case '#': return !event.ctrlKey
+      ? some(KeyK.Hash)
+      : some(KeyK.CtrlHash);
+    case 'Pause': return some(KeyK.Pause);
     // Keys specific to on-screen keyboard
     case '{num}': return some(KeyK.NumLayout);
     case '{abc}': return some(KeyK.AbcLayout);


### PR DESCRIPTION
Fixes #218:
- Pause pauses in play, pause/enter/escape/space resumes in overlay.
- `!`, `@`, `#` will check square, entry, grid, use with `Ctrl` to reveal.
- `@` toggles autofill in constructor.

Labeled WIP because I'm not entirely happy with this.
- Need to move things inside reducer at this point, how to run constructor stuff and dispatch other events in the reducer? Or maybe don't have things inside reducer?
- Not sure if those are good key bindings.
- Probably want to make `Key = { k: KeyK, mods: Modifier[] }` or something.
- Icons are pretty ugly lol, also maybe could be generalized?
- How does shift-arrow navigation work? (#148) 🤔 
- Should escape just work on every possible menu?