### PR TITLE
Hide suggestion bar on mobile

### DIFF
--- a/app/components/HiddenInput.tsx
+++ b/app/components/HiddenInput.tsx
@@ -33,6 +33,7 @@ export const HiddenInput = forwardRef<
     <input
       autoCapitalize="characters"
       autoCorrect="off"
+      spellCheck={false}
       css={{
         width: 1,
         height: 1,


### PR DESCRIPTION
See [the docs on spellcheck](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/text#spellcheck).

<details>
<summary>screenshots</summary>
## iOS simulator
<img width="389" alt="image" src="https://user-images.githubusercontent.com/7526790/225098759-161a345b-4a19-4e96-bbdd-54a4bc4401f9.png">
</details>
