### PR TITLE
Add byline to puzzle page

### DIFF
--- a/app/components/Page.tsx
+++ b/app/components/Page.tsx
@@ -7,6 +7,9 @@ import {
   LARGE_AND_UP,
   TINY_COL_MIN_HEIGHT,
   SQUARE_HEADER_HEIGHT,
+  SQUARE_TITLEBAR_HEIGHT,
+  TINY_TOTAL_MIN_HEIGHT,
+  SQUARE_TOTAL_HEADER_HEIGHT
 } from '../lib/style';
 import { KeyK } from '../lib/types';
 import { usePolyfilledResizeObserver } from '../lib/hooks';
@@ -57,6 +60,7 @@ interface SquareAndColsProps {
   left: ReactNode;
   right: ReactNode;
   header?: ReactNode;
+  titlebar?: ReactNode;
   leftIsActive: boolean;
   dispatch: Dispatch<KeypressAction | PasteAction>;
 }
@@ -103,6 +107,15 @@ export const SquareAndCols = (props: SquareAndColsProps) => {
         >
           <div
             css={{
+              height: SQUARE_TITLEBAR_HEIGHT,
+              display: 'block',
+              overflow: 'hidden'
+            }}
+          >
+            {props.titlebar}
+          </div>
+          <div
+            css={{
               height: SQUARE_HEADER_HEIGHT,
               display: 'none',
               overflow: 'hidden',
@@ -118,26 +131,26 @@ export const SquareAndCols = (props: SquareAndColsProps) => {
             css={{
               margin: 'auto',
               width: useCQ
-                ? `min(100cqw, 100cqh * ${props.aspectRatio} - ${TINY_COL_MIN_HEIGHT}px * ${props.aspectRatio})`
-                : `min(${cqw}px, ${cqh}px * ${props.aspectRatio} - ${TINY_COL_MIN_HEIGHT}px * ${props.aspectRatio})`,
+                ? `min(100cqw, 100cqh * ${props.aspectRatio} - ${TINY_TOTAL_MIN_HEIGHT}px * ${props.aspectRatio})`
+                : `min(${cqw}px, ${cqh}px * ${props.aspectRatio} - ${TINY_TOTAL_MIN_HEIGHT}px * ${props.aspectRatio})`,
               height: useCQ
-                ? `min(100cqh - ${TINY_COL_MIN_HEIGHT}px, 100cqw / ${props.aspectRatio})`
-                : `min(${cqh}px - ${TINY_COL_MIN_HEIGHT}px, ${cqw}px / ${props.aspectRatio})`,
+                ? `min(100cqh - ${TINY_TOTAL_MIN_HEIGHT}px, 100cqw / ${props.aspectRatio})`
+                : `min(${cqh}px - ${TINY_TOTAL_MIN_HEIGHT}px, ${cqw}px / ${props.aspectRatio})`,
               [SMALL_AND_UP]: {
                 width: useCQ
-                  ? `min(66cqw, 100cqh * ${props.aspectRatio} - ${SQUARE_HEADER_HEIGHT}px * ${props.aspectRatio})`
-                  : `min(0.66 * ${cqw}px, ${cqh}px * ${props.aspectRatio} - ${SQUARE_HEADER_HEIGHT}px * ${props.aspectRatio})`,
+                  ? `min(66cqw, 100cqh * ${props.aspectRatio} - ${SQUARE_TOTAL_HEADER_HEIGHT}px * ${props.aspectRatio})`
+                  : `min(0.66 * ${cqw}px, ${cqh}px * ${props.aspectRatio} - ${SQUARE_TOTAL_HEADER_HEIGHT}px * ${props.aspectRatio})`,
                 height: useCQ
-                  ? `min(100cqh - ${SQUARE_HEADER_HEIGHT}px, 66cqw / ${props.aspectRatio})`
-                  : `min(${cqh}px - ${SQUARE_HEADER_HEIGHT}px, 0.66 * ${cqw}px / ${props.aspectRatio})`,
+                  ? `min(100cqh - ${SQUARE_TOTAL_HEADER_HEIGHT}px, 66cqw / ${props.aspectRatio})`
+                  : `min(${cqh}px - ${SQUARE_TOTAL_HEADER_HEIGHT}px, 0.66 * ${cqw}px / ${props.aspectRatio})`,
               },
               [LARGE_AND_UP]: {
                 width: useCQ
-                  ? `min(50cqw, 100cqh * ${props.aspectRatio} - ${SQUARE_HEADER_HEIGHT}px * ${props.aspectRatio})`
-                  : `min(0.5 * ${cqw}px, ${cqh}px * ${props.aspectRatio} - ${SQUARE_HEADER_HEIGHT}px * ${props.aspectRatio})`,
+                  ? `min(50cqw, 100cqh * ${props.aspectRatio} - ${SQUARE_TOTAL_HEADER_HEIGHT}px * ${props.aspectRatio})`
+                  : `min(0.5 * ${cqw}px, ${cqh}px * ${props.aspectRatio} - ${SQUARE_TOTAL_HEADER_HEIGHT}px * ${props.aspectRatio})`,
                 height: useCQ
-                  ? `min(100cqh - ${SQUARE_HEADER_HEIGHT}px, 50cqw / ${props.aspectRatio})`
-                  : `min(${cqh}px - ${SQUARE_HEADER_HEIGHT}px, 0.5 * ${cqw}px / ${props.aspectRatio})`,
+                  ? `min(100cqh - ${SQUARE_TOTAL_HEADER_HEIGHT}px, 50cqw / ${props.aspectRatio})`
+                  : `min(${cqh}px - ${SQUARE_TOTAL_HEADER_HEIGHT}px, 0.5 * ${cqw}px / ${props.aspectRatio})`,
               },
             }}
           >

--- a/app/components/Page.tsx
+++ b/app/components/Page.tsx
@@ -108,8 +108,8 @@ export const SquareAndCols = (props: SquareAndColsProps) => {
           <div
             css={{
               height: SQUARE_TITLEBAR_HEIGHT,
-              display: 'block',
-              overflow: 'hidden'
+              display: props.header !== undefined ? 'block' : 'none',
+              overflow: 'hidden',
             }}
           >
             {props.titlebar}

--- a/app/components/Puzzle.tsx
+++ b/app/components/Puzzle.tsx
@@ -107,7 +107,9 @@ import {
   FULLSCREEN_CSS,
   SMALL_AND_UP_RULES,
   SQUARE_HEADER_HEIGHT,
+  SQUARE_TITLEBAR_HEIGHT,
 } from '../lib/style';
+import { PatronIcon } from './Icons';
 import { Keyboard } from './Keyboard';
 import { useRouter } from 'next/router';
 import { Button } from './Buttons';
@@ -172,6 +174,48 @@ const KeepTryingOverlay = ({
     </Overlay>
   );
 };
+
+const PuzzleTitlebar = memo(function PuzzleTitlebar({
+  puzzleTitle,
+  puzzleAuthor,
+  isPatron
+}: {
+  puzzleTitle: string;
+  puzzleAuthor: string;
+  isPatron: boolean;
+}) {
+  let byline;
+  if (isPatron) {
+    byline = (<div>By <PatronIcon linkIt={false} /> {puzzleAuthor}</div>)
+  }
+  else {
+    byline = (<div>By {puzzleAuthor}</div>)
+  }
+  return (
+    <div
+      css={{
+        height: SQUARE_TITLEBAR_HEIGHT,
+        fontSize: 18,
+        lineHeight: '24px',
+        backgroundColor: 'var(--lighter)',
+        overflowY: 'scroll',
+        scrollbarWidth: 'none',
+        display: 'flex',
+        flexWrap: 'wrap',
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderBottom: '1px dotted black'
+      }}
+    >
+      <div css={{textAlign:'center',width:'100%',paddingTop:'5px'}}><b>
+        {puzzleTitle}
+      </b></div>
+      <div css={{textAlign:'center',paddingBottom:'5px'}}><i>
+        {byline}
+      </i></div>
+    </div>
+  );
+});
 
 const AboveTheGridClue = memo(function AboveTheGridClue({
   entry,
@@ -798,6 +842,13 @@ export const Puzzle = ({
             wrongCells={state.wrongCells}
             showAlternates={state.success ? state.alternateSolutions : null}
             answers={state.answers}
+          />
+        }
+        titlebar={
+          <PuzzleTitlebar
+            puzzleTitle={puzzle.title}
+            puzzleAuthor={puzzle.authorName}
+            isPatron={puzzle.constructorIsPatron}
           />
         }
         header={

--- a/app/lib/serverOnly.ts
+++ b/app/lib/serverOnly.ts
@@ -195,6 +195,8 @@ export const getPuzzlePageProps: GetServerSideProps<PuzzlePageProps> = async ({
     titleSlug = puzzleId[1] || '';
     puzzleId = puzzleId[0];
   }
+  //console.log('hi');
+  //console.log(puzzleId);
   if (!puzzleId) {
     res.statusCode = 404;
     return { props: { error: 'missing puzzleId' } };

--- a/app/lib/serverOnly.ts
+++ b/app/lib/serverOnly.ts
@@ -195,8 +195,6 @@ export const getPuzzlePageProps: GetServerSideProps<PuzzlePageProps> = async ({
     titleSlug = puzzleId[1] || '';
     puzzleId = puzzleId[0];
   }
-  //console.log('hi');
-  //console.log(puzzleId);
   if (!puzzleId) {
     res.statusCode = 404;
     return { props: { error: 'missing puzzleId' } };

--- a/app/lib/style.ts
+++ b/app/lib/style.ts
@@ -10,6 +10,9 @@ export const COVER_PIC: [number, number] = [1200, 400];
 
 export const TINY_COL_MIN_HEIGHT = 50;
 export const SQUARE_HEADER_HEIGHT = 68;
+export const SQUARE_TITLEBAR_HEIGHT = 60;
+export const TINY_TOTAL_MIN_HEIGHT = TINY_COL_MIN_HEIGHT+SQUARE_TITLEBAR_HEIGHT;
+export const SQUARE_TOTAL_HEADER_HEIGHT = SQUARE_HEADER_HEIGHT+SQUARE_TITLEBAR_HEIGHT;
 export const SMALL_BREAKPOINT = 576;
 export const LARGE_BREAKPOINT = 992;
 export const SMALL_AND_UP_RULES = '(min-width: ' + SMALL_BREAKPOINT + 'px)';


### PR DESCRIPTION
Adds the title and author name to the puzzle-solving interface. Includes the patron icon and adapts about as well as could be expected with absurdly long titles. Seems to adapt properly to odd aspect ratios, both of the window and puzzle. I elected to not make the author name link out directly so that mobile users don't accidentally tap it or something.

Resolves #391 (I think this is how github works)