### PR TITLE
Update Dockerfile to build dev on arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM mcr.microsoft.com/playwright:v1.32.2-jammy as dev
 RUN mkdir /src
 WORKDIR /src
 COPY app/package.json app/yarn.lock ./
+RUN apt-get update && apt-get install -y --no-install-recommends openjdk-11-jre-headless curl build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 RUN yarn --frozen-lockfile
 ENV PATH=$PATH:/src/node_modules/.bin NEXT_TELEMETRY_DISABLED=1
-RUN apt-get update && apt-get install -y --no-install-recommends openjdk-11-jre-headless curl
 RUN npm i -g firebase-tools
 RUN firebase --version
 RUN firebase setup:emulators:firestore


### PR DESCRIPTION
A few libraries (looks like node canvas and rocksdb) do not have arm64 binaries available. npm/yarn will fallback to try to build them from source, but it cannot without build-essential (make) and a group of other packages for node-canvas.

Automattic has documented Ubuntu dependencies in the [compiling section of their readme](https://github.com/Automattic/node-canvas#compiling)

This also moves the apt calls to be before yarn.

Steps to test:

1. retag your old dev, so that you still have it in case things go poorly `docker tag dev crosshare-dev:old` or some such.
2. docker-compose up dev

This build took a _very_ long time for me (10 minutes), so don't get discouraged if it is taking forever.