### PR TITLE
Multi-cell selection, copy, cut, and paste

### DIFF
--- a/app/components/AlternateSolutionEditor.tsx
+++ b/app/components/AlternateSolutionEditor.tsx
@@ -39,6 +39,7 @@ import {
 import { isSome } from 'fp-ts/lib/Option';
 import { GridView } from './Grid';
 import { logAsyncErrors } from '../lib/utils';
+import { isTextInput } from '../lib/domUtils';
 
 export function AlternateSolutionEditor(props: {
   grid: string[];
@@ -107,8 +108,7 @@ export function AlternateSolutionEditor(props: {
 
   const pasteHandler = useCallback(
     (e: ClipboardEvent) => {
-      const tagName = (e.target as HTMLElement).tagName.toLowerCase();
-      if (tagName === 'textarea' || tagName === 'input') {
+      if (isTextInput(e.target)) {
         return;
       }
       const pa: PasteAction = {

--- a/app/components/Builder.tsx
+++ b/app/components/Builder.tsx
@@ -908,11 +908,7 @@ const GridMode = ({
           }
           return;
         }
-        const kpa: KeypressAction = {
-          type: 'KEYPRESS',
-          key: mkey.value,
-          shiftKey: e.shiftKey,
-        };
+        const kpa: KeypressAction = { type: 'KEYPRESS', key: mkey.value };
         dispatch(kpa);
       }
     },

--- a/app/components/Cell.tsx
+++ b/app/components/Cell.tsx
@@ -3,6 +3,7 @@ import { memo, useEffect, useRef, useState } from 'react';
 
 import { FaSlash, FaEye } from 'react-icons/fa';
 import { usePolyfilledResizeObserver } from '../lib/hooks';
+import { Position } from '../lib/types';
 
 const blink = keyframes`
 from, to {
@@ -45,12 +46,16 @@ interface CellProps {
   entryCell: boolean;
   refedCell: boolean;
   highlightCell: boolean;
+  selected: boolean;
+  isSelecting: boolean;
   highlight: 'circle' | 'shade' | undefined;
   value: string;
   number: string;
   row: number;
   column: number;
-  onClick: (pos: { row: number; col: number }) => void;
+  onClick: (pos: Position, shiftKey: boolean) => void;
+  onMouseDown: (pos: Position) => void;
+  onMouseEnter: (pos: Position) => void;
   isVerified: boolean | undefined;
   isWrong: boolean | undefined;
   wasRevealed: boolean | undefined;
@@ -90,7 +95,11 @@ export const Cell = memo(function Cell(props: CellProps) {
     bg = 'var(--primary)';
     text = 'var(--onprimary)';
     verified = 'var(--verified-on-primary)';
-  } else if (props.entryCell) {
+  } else if (props.selected) {
+    bg = 'var(--highlight)';
+    text = 'var(--on-highlight)';
+    verified = 'var(--verified-on-highlight)';
+  } else if (props.entryCell && !props.isSelecting) {
     bg = 'var(--lighter)';
     text = 'var(--on-lighter)';
     verified = 'var(--verified-on-lighter)';
@@ -140,8 +149,18 @@ export const Cell = memo(function Cell(props: CellProps) {
       {/* eslint-disable-next-line */}
       <div
         aria-label={`cell${props.row}x${props.column}`}
-        onClick={() => {
-          props.onClick({ row: props.row, col: props.column });
+        onClick={(evt) => {
+          props.onClick({ row: props.row, col: props.column }, evt.shiftKey);
+        }}
+        onMouseDown={(evt) => {
+          if (evt.buttons === 1) {
+            props.onMouseDown({ row: props.row, col: props.column });
+          }
+        }}
+        onMouseEnter={(evt) => {
+          if (evt.buttons === 1) {
+            props.onMouseEnter({ row: props.row, col: props.column });
+          }
         }}
         css={{
           userSelect: 'none',

--- a/app/components/Cell.tsx
+++ b/app/components/Cell.tsx
@@ -87,7 +87,7 @@ export const Cell = memo(function Cell(props: CellProps) {
       'repeating-linear-gradient(-45deg,var(--cell-wall),var(--cell-wall) 10px,var(--primary) 10px,var(--primary) 20px);';
   } else if (props.isBlock && props.selected) {
     bg =
-      'repeating-linear-gradient(-45deg,var(--cell-wall),var(--cell-wall) 10px,var(--highlight) 10px,var(--highlight) 20px);';
+      'repeating-linear-gradient(-45deg,var(--cell-wall),var(--cell-wall) 10px,var(--selected-cell) 10px,var(--selected-cell) 20px);';
   } else if (props.isBlock) {
     bg = 'var(--cell-wall)';
   } else if (props.cellColor !== undefined) {
@@ -99,9 +99,9 @@ export const Cell = memo(function Cell(props: CellProps) {
     text = 'var(--onprimary)';
     verified = 'var(--verified-on-primary)';
   } else if (props.selected) {
-    bg = 'var(--highlight)';
-    text = 'var(--on-highlight)';
-    verified = 'var(--verified-on-highlight)';
+    bg = 'var(--selected-cell)';
+    text = 'var(--on-selected-cell)';
+    verified = 'var(--verified-on-selected-cell)';
   } else if (props.entryCell && !props.isSelecting) {
     bg = 'var(--lighter)';
     text = 'var(--on-lighter)';

--- a/app/components/Cell.tsx
+++ b/app/components/Cell.tsx
@@ -85,6 +85,9 @@ export const Cell = memo(function Cell(props: CellProps) {
   } else if (props.isBlock && props.active) {
     bg =
       'repeating-linear-gradient(-45deg,var(--cell-wall),var(--cell-wall) 10px,var(--primary) 10px,var(--primary) 20px);';
+  } else if (props.isBlock && props.selected) {
+    bg =
+      'repeating-linear-gradient(-45deg,var(--cell-wall),var(--cell-wall) 10px,var(--highlight) 10px,var(--highlight) 20px);';
   } else if (props.isBlock) {
     bg = 'var(--cell-wall)';
   } else if (props.cellColor !== undefined) {

--- a/app/components/Puzzle.tsx
+++ b/app/components/Puzzle.tsx
@@ -161,6 +161,7 @@ import {
 import { removeSpoilers } from '../lib/markdown/markdown';
 import { SlateBegin, SlatePause } from './SlateOverlays';
 import { SolverPreferencesList } from './SolverPreferencesList';
+import { isTextInput } from '../lib/domUtils';
 
 const ModeratingOverlay = dynamic(
   () => import('./ModerateOverlay').then((mod) => mod.ModeratingOverlay),
@@ -731,8 +732,7 @@ export const Puzzle = ({
 
   const pasteHandler = useCallback(
     (e: ClipboardEvent) => {
-      const tagName = (e.target as HTMLElement).tagName.toLowerCase();
-      if (tagName === 'textarea' || tagName === 'input') {
+      if (isTextInput(e.target)) {
         return;
       }
 

--- a/app/lib/domUtils.ts
+++ b/app/lib/domUtils.ts
@@ -1,0 +1,4 @@
+export function isTextInput(target: EventTarget | null): boolean {
+  const tagName = (target as HTMLElement | null)?.tagName.toLowerCase();
+  return tagName === 'textarea' || tagName === 'input';
+}

--- a/app/lib/gridBase.ts
+++ b/app/lib/gridBase.ts
@@ -117,6 +117,29 @@ export function posForIndex<Entry extends EntryBase>(
   };
 }
 
+export function isInBounds<Entry extends EntryBase>(
+  grid: GridBase<Entry>,
+  pos: Position
+): boolean {
+  return (
+    pos.col >= 0 &&
+    pos.col < grid.width &&
+    pos.row >= 0 &&
+    pos.row < grid.height
+  );
+}
+
+export function clampInBounds<Entry extends EntryBase>(
+  grid: GridBase<Entry>,
+  pos: PosAndDir
+): PosAndDir {
+  return {
+    row: Math.min(grid.height - 1, Math.max(0, pos.row)),
+    col: Math.min(grid.width - 1, Math.max(0, pos.col)),
+    dir: pos.dir,
+  };
+}
+
 export function entryIndexAtPosition<Entry extends EntryBase>(
   grid: GridBase<Entry>,
   pos: PosAndDir

--- a/app/lib/selection.ts
+++ b/app/lib/selection.ts
@@ -36,8 +36,8 @@ export function forEachPosition(
 
 export function getSelectionCells(selection?: GridSelection): Position[] {
   const res: Position[] = [];
-  if (hasMultipleCells(selection)) {
-    forEachPosition(selection!, (pos) => res.push(pos));
+  if (!!selection && hasMultipleCells(selection)) {
+    forEachPosition(selection, (pos) => res.push(pos));
   }
   return res;
 }

--- a/app/lib/selection.ts
+++ b/app/lib/selection.ts
@@ -1,0 +1,43 @@
+import { Position, isSamePosition } from './types';
+
+export interface GridSelection {
+  start: Position;
+  end: Position;
+}
+
+export function emptySelection(
+  position: Position = { col: 0, row: 0 }
+): GridSelection {
+  return {
+    start: { ...position },
+    end: { ...position },
+  };
+}
+
+export function hasMultipleCells(selection?: GridSelection): boolean {
+  return !!selection && !isSamePosition(selection.start, selection.end);
+}
+
+export function forEachPosition(
+  selection: GridSelection,
+  callback: (position: Position) => void
+): void {
+  const { start, end } = selection;
+  const startRow = Math.min(start.row, end.row);
+  const endRow = Math.max(start.row, end.row);
+  const startCol = Math.min(start.col, end.col);
+  const endCol = Math.max(start.col, end.col);
+  for (let row = startRow; row <= endRow; row++) {
+    for (let col = startCol; col <= endCol; col++) {
+      callback({ row, col });
+    }
+  }
+}
+
+export function getSelectionCells(selection?: GridSelection): Position[] {
+  const res: Position[] = [];
+  if (hasMultipleCells(selection)) {
+    forEachPosition(selection!, (pos) => res.push(pos));
+  }
+  return res;
+}

--- a/app/lib/style.ts
+++ b/app/lib/style.ts
@@ -104,6 +104,7 @@ export const colorTheme = ({
   const text = darkMode ? DARK_MODE_WHITE : 'black';
   const secondary = darkMode ? '#505050' : '#ccc';
   const lighter = mix(p, cellBG, 0.6);
+  const highlight = darkMode ? '#a880ff' : '#c484ff';
 
   return {
     '--tag-l': darkMode ? '30%' : '85%',
@@ -117,6 +118,8 @@ export const colorTheme = ({
     '--on-lighter': readableColor(lighter, darkMode),
     '--secondary': secondary,
     '--on-secondary': readableColor(secondary, darkMode),
+    '--highlight': highlight,
+    '--on-highlight': readableColor(highlight, darkMode),
     '--bg-hover': mix(bg, hover, hoverRatio),
     '--secondary-hover': mix(secondary, hover, hoverRatio),
     '--boring-bg': darkMode ? '#b5b5b5' : '#555',
@@ -141,6 +144,7 @@ export const colorTheme = ({
     '--verified-on-lighter': makeReadable(lighter, verified),
     '--verified-on-bg': makeReadable(cellBG, verified),
     '--verified-on-secondary': makeReadable(secondary, verified),
+    '--verified-on-highlight': makeReadable(highlight, verified),
     '--autofill': darkMode ? '#999' : '#bbb',
     '--top-bar-hover': 'rgba(0, 0, 0, 0.1)',
     '--shade-highlight': darkMode

--- a/app/lib/style.ts
+++ b/app/lib/style.ts
@@ -104,7 +104,7 @@ export const colorTheme = ({
   const text = darkMode ? DARK_MODE_WHITE : 'black';
   const secondary = darkMode ? '#505050' : '#ccc';
   const lighter = mix(p, cellBG, 0.6);
-  const highlight = darkMode ? '#a880ff' : '#c484ff';
+  const selectedCell = darkMode ? '#a880ff' : '#c484ff';
 
   return {
     '--tag-l': darkMode ? '30%' : '85%',
@@ -118,8 +118,8 @@ export const colorTheme = ({
     '--on-lighter': readableColor(lighter, darkMode),
     '--secondary': secondary,
     '--on-secondary': readableColor(secondary, darkMode),
-    '--highlight': highlight,
-    '--on-highlight': readableColor(highlight, darkMode),
+    '--selected-cell': selectedCell,
+    '--on-selected-cell': readableColor(selectedCell, darkMode),
     '--bg-hover': mix(bg, hover, hoverRatio),
     '--secondary-hover': mix(secondary, hover, hoverRatio),
     '--boring-bg': darkMode ? '#b5b5b5' : '#555',
@@ -144,7 +144,7 @@ export const colorTheme = ({
     '--verified-on-lighter': makeReadable(lighter, verified),
     '--verified-on-bg': makeReadable(cellBG, verified),
     '--verified-on-secondary': makeReadable(secondary, verified),
-    '--verified-on-highlight': makeReadable(highlight, verified),
+    '--verified-on-selected-cell': makeReadable(selectedCell, verified),
     '--autofill': darkMode ? '#999' : '#bbb',
     '--top-bar-hover': 'rgba(0, 0, 0, 0.1)',
     '--shade-highlight': darkMode

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -36,8 +36,8 @@ export const fromEnum = <T extends string, TEnumValue extends string | number>(
 
 export const BLOCK = '.';
 export const EMPTY = ' ';
-export const CELL_DELIMETER = ',';
-export const ROW_DELIMETER = '\n';
+export const CELL_DELIMITER = ',';
+export const ROW_DELIMITER = '\n';
 
 export enum Symmetry {
   Rotational,

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -369,6 +369,10 @@ export enum KeyK {
   ArrowLeft,
   ArrowUp,
   ArrowDown,
+  ShiftArrowRight,
+  ShiftArrowLeft,
+  ShiftArrowUp,
+  ShiftArrowDown,
   Space,
   Tab,
   ShiftTab,
@@ -423,13 +427,19 @@ export function fromKeyboardEvent(event: {
   const basicKey: Option<Exclude<KeyK, KeyK.AllowedCharacter>> = (() => {
     switch (event.key) {
       case 'ArrowLeft':
-        return some(KeyK.ArrowLeft);
+        return !event.shiftKey
+          ? some(KeyK.ArrowLeft)
+          : some(KeyK.ShiftArrowLeft);
       case 'ArrowRight':
-        return some(KeyK.ArrowRight);
+        return !event.shiftKey
+          ? some(KeyK.ArrowRight)
+          : some(KeyK.ShiftArrowRight);
       case 'ArrowUp':
-        return some(KeyK.ArrowUp);
+        return !event.shiftKey ? some(KeyK.ArrowUp) : some(KeyK.ShiftArrowUp);
       case 'ArrowDown':
-        return some(KeyK.ArrowDown);
+        return !event.shiftKey
+          ? some(KeyK.ArrowDown)
+          : some(KeyK.ShiftArrowDown);
       case ' ':
         return some(KeyK.Space);
       case 'Tab':

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -5,6 +5,7 @@ import type { WordDBT } from './WordDB';
 import { DBPuzzleT, CommentWithRepliesT, GlickoScoreT } from '../lib/dbtypes';
 import { ConstructorPageWithMarkdown } from '../lib/constructorPage';
 import type { Root } from 'hast';
+import { isTextInput } from './domUtils';
 
 export type Optionalize<T extends K, K> = Omit<T, keyof K>;
 export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
@@ -34,6 +35,8 @@ export const fromEnum = <T extends string, TEnumValue extends string | number>(
 };
 
 export const BLOCK = '.';
+export const EMPTY = ' ';
+export const DELIMETER = ',';
 
 export enum Symmetry {
   Rotational,
@@ -117,6 +120,14 @@ export interface Position {
 
 export interface PosAndDir extends Position {
   dir: Direction;
+}
+
+export function asPosition({ row, col }: PosAndDir): Position {
+  return { row, col };
+}
+
+export function isSamePosition(a: Position, b: Position): boolean {
+  return a.row === b.row && a.col === b.col;
 }
 
 export interface ClueT {
@@ -403,8 +414,7 @@ export function fromKeyboardEvent(event: {
   target?: EventTarget | null;
 }): Option<Key> {
   if (event.target) {
-    const tagName = (event.target as HTMLElement).tagName.toLowerCase();
-    if (tagName === 'textarea' || tagName === 'input') {
+    if (isTextInput(event.target)) {
       return none;
     }
   }

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -36,7 +36,8 @@ export const fromEnum = <T extends string, TEnumValue extends string | number>(
 
 export const BLOCK = '.';
 export const EMPTY = ' ';
-export const DELIMETER = ',';
+export const CELL_DELIMETER = ',';
+export const ROW_DELIMETER = '\n';
 
 export enum Symmetry {
   Rotational,
@@ -120,10 +121,6 @@ export interface Position {
 
 export interface PosAndDir extends Position {
   dir: Direction;
-}
-
-export function asPosition({ row, col }: PosAndDir): Position {
-  return { row, col };
 }
 
 export function isSamePosition(a: Position, b: Position): boolean {

--- a/app/reducers/reducer.ts
+++ b/app/reducers/reducer.ts
@@ -785,7 +785,7 @@ function enterCharAt<T extends GridInterfaceState>(
     const symmetry = isBuilderState(state) ? state.symmetry : Symmetry.None;
     let grid = state.grid;
     if (char === BLOCK) {
-      if (valAt(grid, pos) !== BLOCK) {
+      if (valAt(grid, pos) !== BLOCK && grid.allowBlockEditing) {
         grid = gridWithBlockToggled(grid, pos, symmetry);
       }
     } else {

--- a/app/reducers/reducer.ts
+++ b/app/reducers/reducer.ts
@@ -767,13 +767,15 @@ function postEdit(
 }
 
 function enterText<T extends GridInterfaceState>(state: T, text: string): T {
-  return enterCharAt(state, state.active, text);
+  const symmetry = isBuilderState(state) ? state.symmetry : Symmetry.None;
+  return enterCharAt(state, state.active, text, symmetry);
 }
 
 function enterCharAt<T extends GridInterfaceState>(
   state: T,
   pos: Position,
-  char: string
+  char: string,
+  symmetry: Symmetry,
 ): T {
   const ci = cellIndex(state.grid, pos);
   if (state.isEditable(ci)) {
@@ -782,7 +784,6 @@ function enterCharAt<T extends GridInterfaceState>(
       state.cellsUpdatedAt[ci] = elapsed;
       state.cellsIterationCount[ci] += 1;
     }
-    const symmetry = isBuilderState(state) ? state.symmetry : Symmetry.None;
     let grid = state.grid;
     if (char === BLOCK) {
       if (valAt(grid, pos) !== BLOCK && grid.allowBlockEditing) {
@@ -919,7 +920,7 @@ export function gridInterfaceReducer<T extends GridInterfaceState>(
         const val = valAt(grid, pos);
         toCopy += val + CELL_DELIMITER;
         if (isCutAction(action)) {
-          state = enterCharAt(state, pos, EMPTY);
+          state = enterCharAt(state, pos, EMPTY, Symmetry.None);
         }
       });
     } else {
@@ -965,7 +966,7 @@ export function gridInterfaceReducer<T extends GridInterfaceState>(
         current.row = start.row + dRow;
         current.col = start.col + dCol;
         if (isInBounds(state.grid, current)) {
-          state = enterCharAt(state, current, cellStr);
+          state = enterCharAt(state, current, cellStr, Symmetry.None);
         }
       });
     });

--- a/app/reducers/reducer.ts
+++ b/app/reducers/reducer.ts
@@ -775,7 +775,7 @@ function enterCharAt<T extends GridInterfaceState>(
   state: T,
   pos: Position,
   char: string,
-  symmetry: Symmetry,
+  symmetry: Symmetry
 ): T {
   const ci = cellIndex(state.grid, pos);
   if (state.isEditable(ci)) {

--- a/app/reducers/reducer.ts
+++ b/app/reducers/reducer.ts
@@ -11,8 +11,8 @@ import {
   PrefillSquares,
   CheatUnit,
   EMPTY,
-  CELL_DELIMETER,
-  ROW_DELIMETER,
+  CELL_DELIMITER,
+  ROW_DELIMITER,
 } from '../lib/types';
 import { DBPuzzleT, PlayWithoutUserT } from '../lib/dbtypes';
 import {
@@ -913,11 +913,11 @@ export function gridInterfaceReducer<T extends GridInterfaceState>(
       let row: number;
       forEachPosition(state.selection, (pos) => {
         if (row != null && row !== pos.row) {
-          toCopy += ROW_DELIMETER;
+          toCopy += ROW_DELIMITER;
         }
         row = pos.row;
         const val = valAt(grid, pos);
-        toCopy += val + CELL_DELIMETER;
+        toCopy += val + CELL_DELIMITER;
         if (isCutAction(action)) {
           state = enterCharAt(state, pos, EMPTY);
         }
@@ -937,9 +937,9 @@ export function gridInterfaceReducer<T extends GridInterfaceState>(
     return state;
   }
   if (isPasteAction(action)) {
-    const toPaste = action.content.split(ROW_DELIMETER).map((r) =>
+    const toPaste = action.content.split(ROW_DELIMITER).map((r) =>
       r
-        .split(CELL_DELIMETER)
+        .split(CELL_DELIMITER)
         .filter((s) => s.length > 0)
         .map((s) =>
           s

--- a/app/reducers/reducer.ts
+++ b/app/reducers/reducer.ts
@@ -303,7 +303,6 @@ export interface PuzzleAction {
 export interface KeypressAction extends PuzzleAction {
   type: 'KEYPRESS';
   key: Key;
-  shiftKey?: boolean;
 }
 function isKeypressAction(action: PuzzleAction): action is KeypressAction {
   return action.type === 'KEYPRESS';
@@ -1088,20 +1087,19 @@ export function gridInterfaceReducer<T extends GridInterfaceState>(
         wasEntryClick: false,
         active: moveToPrevEntry(state.grid, state.active),
       };
-    } else if (key.k === KeyK.ArrowRight) {
-      if (isBuilderState(state) && action.shiftKey) {
-        const { start, end } = hasSelection(state)
-          ? state.selection
-          : emptySelection(state.active);
-        return {
-          ...state,
-          wasEntryClick: false,
-          selection: {
-            start,
-            end: moveRight(state.grid, end),
-          },
-        };
-      }
+    } else if (key.k === KeyK.ShiftArrowRight && isBuilderState(state)) {
+      const { start, end } = hasSelection(state)
+        ? state.selection
+        : emptySelection(state.active);
+      return {
+        ...state,
+        wasEntryClick: false,
+        selection: {
+          start,
+          end: moveRight(state.grid, end),
+        },
+      };
+    } else if (key.k === KeyK.ArrowRight || key.k === KeyK.ShiftArrowRight) {
       state = clearSelection(state);
       return {
         ...state,
@@ -1114,20 +1112,19 @@ export function gridInterfaceReducer<T extends GridInterfaceState>(
           dir: Direction.Across,
         },
       };
-    } else if (key.k === KeyK.ArrowLeft) {
-      if (isBuilderState(state) && action.shiftKey) {
-        const { start, end } = hasSelection(state)
-          ? state.selection
-          : emptySelection(state.active);
-        return {
-          ...state,
-          wasEntryClick: false,
-          selection: {
-            start,
-            end: moveLeft(state.grid, end),
-          },
-        };
-      }
+    } else if (key.k === KeyK.ShiftArrowLeft && isBuilderState(state)) {
+      const { start, end } = hasSelection(state)
+        ? state.selection
+        : emptySelection(state.active);
+      return {
+        ...state,
+        wasEntryClick: false,
+        selection: {
+          start,
+          end: moveLeft(state.grid, end),
+        },
+      };
+    } else if (key.k === KeyK.ArrowLeft || key.k === KeyK.ShiftArrowLeft) {
       state = clearSelection(state);
       return {
         ...state,
@@ -1140,20 +1137,19 @@ export function gridInterfaceReducer<T extends GridInterfaceState>(
           dir: Direction.Across,
         },
       };
-    } else if (key.k === KeyK.ArrowUp) {
-      if (isBuilderState(state) && action.shiftKey) {
-        const { start, end } = hasSelection(state)
-          ? state.selection
-          : emptySelection(state.active);
-        return {
-          ...state,
-          wasEntryClick: false,
-          selection: {
-            start,
-            end: moveUp(state.grid, end),
-          },
-        };
-      }
+    } else if (key.k === KeyK.ShiftArrowUp && isBuilderState(state)) {
+      const { start, end } = hasSelection(state)
+        ? state.selection
+        : emptySelection(state.active);
+      return {
+        ...state,
+        wasEntryClick: false,
+        selection: {
+          start,
+          end: moveUp(state.grid, end),
+        },
+      };
+    } else if (key.k === KeyK.ArrowUp || key.k === KeyK.ShiftArrowUp) {
       state = clearSelection(state);
       return {
         ...state,
@@ -1166,20 +1162,19 @@ export function gridInterfaceReducer<T extends GridInterfaceState>(
           dir: Direction.Down,
         },
       };
-    } else if (key.k === KeyK.ArrowDown) {
-      if (isBuilderState(state) && action.shiftKey) {
-        const { start, end } = hasSelection(state)
-          ? state.selection
-          : emptySelection(state.active);
-        return {
-          ...state,
-          wasEntryClick: false,
-          selection: {
-            start,
-            end: moveDown(state.grid, end),
-          },
-        };
-      }
+    } else if (key.k === KeyK.ShiftArrowDown && isBuilderState(state)) {
+      const { start, end } = hasSelection(state)
+        ? state.selection
+        : emptySelection(state.active);
+      return {
+        ...state,
+        wasEntryClick: false,
+        selection: {
+          start,
+          end: moveDown(state.grid, end),
+        },
+      };
+    } else if (key.k === KeyK.ArrowDown || key.k === KeyK.ShiftArrowDown) {
       state = clearSelection(state);
       return {
         ...state,


### PR DESCRIPTION
This PR adds multi-cell selection to the builder! It also extends delete and paste to handle selected regions, and adds new cut and copy functionality for both single cells and selected regions

You can control multi-cell selection in a few different ways:
- click and drag
- shift-click
- shift + arrow keys

Closes https://github.com/crosshare-org/crosshare/issues/476

<img width="305" alt="Screenshot 2024-04-04 at 7 13 09 PM" src="https://github.com/crosshare-org/crosshare/assets/1813467/126a6543-00cc-40e6-b6ac-d39bc412a12f">

<img width="307" alt="Screenshot 2024-04-04 at 7 28 43 PM" src="https://github.com/crosshare-org/crosshare/assets/1813467/fc5a1d1c-ed3f-4f7f-a47e-cf5a591483ea">

