### PR TITLE
Explicitly define grid diff for undo/redo

### DIFF
--- a/app/lib/viewableGrid.ts
+++ b/app/lib/viewableGrid.ts
@@ -19,6 +19,7 @@ import { AccountPrefsFlagsT } from './prefs';
 import type { Root } from 'hast';
 import { toString } from 'hast-util-to-string';
 import { parseClueReferences } from './parse';
+import equal from 'fast-deep-equal/es6';
 
 export interface ViewableEntry extends EntryBase {
   labelNumber: number;
@@ -816,4 +817,17 @@ export function fromCells<
     entries,
     cellLabels,
   } as Grid; // TODO remove assertion after this is fixed: https://github.com/microsoft/TypeScript/issues/28884#issuecomment-448356158
+}
+
+export function gridEqual(
+  a?: ViewableGrid<ViewableEntry>,
+  b?: ViewableGrid<ViewableEntry>
+): boolean {
+  return (
+    equal(a?.cells, b?.cells) &&
+    equal(a?.vBars, b?.vBars) &&
+    equal(a?.hBars, b?.hBars) &&
+    equal(a?.highlighted, b?.highlighted) &&
+    equal(a?.hidden, b?.hidden)
+  );
 }

--- a/app/reducers/builderReducer.ts
+++ b/app/reducers/builderReducer.ts
@@ -7,10 +7,15 @@ import {
   Position,
 } from '../lib/types';
 import { DBPuzzleT } from '../lib/dbtypes';
-import { ViewableGrid, ViewableEntry, fromCells } from '../lib/viewableGrid';
+import {
+  ViewableGrid,
+  ViewableEntry,
+  fromCells,
+  gridEqual,
+} from '../lib/viewableGrid';
 import { gridWithEntrySet } from '../lib/gridBase';
 import { Timestamp } from '../lib/timestamp';
-import equal from 'fast-deep-equal/es6';
+import equal from 'fast-deep-equal';
 import { getDocId } from '../lib/firebaseWrapper';
 import { GridSelection, emptySelection } from '../lib/selection';
 import {
@@ -444,7 +449,7 @@ function removeAnswer(answers: string[], toRemove: string): string[] {
 
 function pushToHistory(state: BuilderState): BuilderState {
   const prevGrid = state.undoHistory[state.undoIndex];
-  if (equal(prevGrid, state.grid)) {
+  if (gridEqual(prevGrid, state.grid)) {
     return state;
   }
 


### PR DESCRIPTION
TL;DR: Fixes a bug in undo/redo that happens when you click a fill suggestion!

---

The builder doesn't explicitly keep track of grid state entry patterns (used by the autofill), but they are de facto updated/captured anywhere `fromCells()` is called, including in the undo stack. However, they are _not_ captured when you click on a fill word. This means clicking on a fill word causes the undo stack to get out of sync with the grid state until the next time you enter a letter or do something else that calls `fromCells()`.

Solution here is to explicitly define what on the grid state matters for undo/redo -- hopefully an allowlist kind of model will be safer (at the expense of a small amount of extra maintenance when adding new undo-able stuff to the grid state).