### PR TITLE
Shift + arrow navigation

### DIFF
--- a/app/components/AlternateSolutionEditor.tsx
+++ b/app/components/AlternateSolutionEditor.tsx
@@ -26,11 +26,8 @@ import {
 } from '../lib/types';
 import { logAsyncErrors } from '../lib/utils';
 import { fromCells } from '../lib/viewableGrid';
-import {
-  KeypressAction,
-  PasteAction,
-  gridInterfaceReducer,
-} from '../reducers/gridReducer';
+import { KeypressAction } from '../reducers/commonActions';
+import { PasteAction, gridInterfaceReducer } from '../reducers/gridReducer';
 import styles from './AlternateSolutionEditor.module.css';
 import { GridView } from './Grid';
 import { EscapeKey, Rebus } from './Icons';

--- a/app/components/Builder.tsx
+++ b/app/components/Builder.tsx
@@ -81,12 +81,11 @@ import {
   getClueProps,
   initialBuilderState,
 } from '../reducers/builderReducer';
-import { PuzzleAction } from '../reducers/commonActions';
+import { KeypressAction, PuzzleAction } from '../reducers/commonActions';
 import {
   ClickedEntryAction,
   CopyAction,
   CutAction,
-  KeypressAction,
   PasteAction,
 } from '../reducers/gridReducer';
 import { AuthProps } from './AuthHelpers';

--- a/app/components/Page.tsx
+++ b/app/components/Page.tsx
@@ -11,7 +11,8 @@ import { FaAngleDoubleLeft, FaAngleDoubleRight } from 'react-icons/fa';
 import { usePolyfilledResizeObserver } from '../lib/hooks';
 import { KeyK } from '../lib/types';
 import { clsx } from '../lib/utils';
-import { KeypressAction, PasteAction } from '../reducers/gridReducer';
+import { KeypressAction } from '../reducers/commonActions';
+import { PasteAction } from '../reducers/gridReducer';
 import { EmbedContext } from './EmbedContext';
 import styles from './Page.module.css';
 

--- a/app/components/Preview.tsx
+++ b/app/components/Preview.tsx
@@ -21,7 +21,7 @@ import {
   getClueProps,
   initialBuilderState,
 } from '../reducers/builderReducer';
-import { KeypressAction } from '../reducers/gridReducer';
+import { KeypressAction } from '../reducers/commonActions';
 import { AuthProps } from './AuthHelpers';
 import { ClueList } from './ClueList';
 import { ClueMode } from './ClueMode';

--- a/app/components/Puzzle.tsx
+++ b/app/components/Puzzle.tsx
@@ -78,8 +78,8 @@ import {
   getEntryToClueMap,
   getRefs,
 } from '../lib/viewableGrid';
-import { PuzzleAction } from '../reducers/commonActions';
-import { KeypressAction, PasteAction } from '../reducers/gridReducer';
+import { KeypressAction, PuzzleAction } from '../reducers/commonActions';
+import { PasteAction } from '../reducers/gridReducer';
 import {
   CheatAction,
   LoadPlayAction,

--- a/app/components/PuzzleStats.tsx
+++ b/app/components/PuzzleStats.tsx
@@ -25,7 +25,7 @@ import {
   builderReducer,
   initialBuilderState,
 } from '../reducers/builderReducer';
-import { KeypressAction } from '../reducers/gridReducer';
+import { KeypressAction } from '../reducers/commonActions';
 import { ButtonAsLink } from './Buttons';
 import { ClueList } from './ClueList';
 import { CopyableInput } from './CopyableInput';

--- a/app/lib/gridBase.ts
+++ b/app/lib/gridBase.ts
@@ -129,6 +129,22 @@ export function isInBounds<Entry extends EntryBase>(
   );
 }
 
+export function isIndexInBounds<Entry extends EntryBase>(
+  grid: GridBase<Entry>,
+  index: number
+): boolean {
+  return index >= 0 && index < grid.width * grid.height;
+}
+
+export function isInDirection(posA: PosAndDir, posB: Position): boolean {
+  switch (posA.dir) {
+    case Direction.Across:
+      return posA.row === posB.row;
+    case Direction.Down:
+      return posA.col === posB.col;
+  }
+}
+
 export function clampInBounds<Entry extends EntryBase>(
   grid: GridBase<Entry>,
   pos: PosAndDir

--- a/app/lib/viewableGrid.ts
+++ b/app/lib/viewableGrid.ts
@@ -7,7 +7,6 @@ import {
   cellIndex,
   entriesFromCells,
   entryAtPosition,
-  isInBounds,
   isInDirection,
   isIndexInBounds,
   posForIndex,
@@ -390,13 +389,15 @@ export function moveToEntry<Entry extends ViewableEntry>(
   pos: PosAndDir,
   move: (grid: ViewableGrid<Entry>, active: Position) => Position
 ): Position {
-  let newPos = move(grid, pos);
-  while (isInBounds(grid, newPos)) {
+  let oldPos: Position = { ...pos };
+  let newPos = move(grid, oldPos);
+  while (!isSamePosition(newPos, oldPos)) {
     const [newEntry] = entryAtPosition(grid, { ...newPos, dir: pos.dir });
     if (newEntry) {
       return newPos;
     }
-    newPos = move(grid, newPos);
+    oldPos = newPos;
+    newPos = move(grid, oldPos);
   }
 
   return pos;

--- a/app/lib/viewableGrid.ts
+++ b/app/lib/viewableGrid.ts
@@ -7,6 +7,7 @@ import {
   cellIndex,
   entriesFromCells,
   entryAtPosition,
+  isInBounds,
   isInDirection,
   isIndexInBounds,
   posForIndex,
@@ -348,7 +349,7 @@ export function moveToNextEntry<Entry extends ViewableEntry>(
   };
 }
 
-export function moveToNextEntryInDirection<Entry extends ViewableEntry>(
+export function moveToEntryInActiveDirection<Entry extends ViewableEntry>(
   grid: ViewableGrid<Entry>,
   pos: PosAndDir,
   reverse = false
@@ -379,6 +380,23 @@ export function moveToNextEntryInDirection<Entry extends ViewableEntry>(
       return newPos;
     }
     newPos = posForIndex(grid, (ci += iincr));
+  }
+
+  return pos;
+}
+
+export function moveToEntry<Entry extends ViewableEntry>(
+  grid: ViewableGrid<Entry>,
+  pos: PosAndDir,
+  move: (grid: ViewableGrid<Entry>, active: Position) => Position
+): Position {
+  let newPos = move(grid, pos);
+  while (isInBounds(grid, newPos)) {
+    const [newEntry] = entryAtPosition(grid, { ...newPos, dir: pos.dir });
+    if (newEntry) {
+      return newPos;
+    }
+    newPos = move(grid, newPos);
   }
 
   return pos;

--- a/app/reducers/builderReducer.ts
+++ b/app/reducers/builderReducer.ts
@@ -7,6 +7,7 @@ import { Timestamp } from '../lib/timestamp';
 import {
   Direction,
   EMPTY,
+  KeyK,
   Position,
   PrefillSquares,
   PuzzleInProgressT,
@@ -17,9 +18,13 @@ import {
   ViewableGrid,
   fromCells,
   gridEqual,
+  moveDown,
+  moveLeft,
+  moveRight,
+  moveUp,
 } from '../lib/viewableGrid';
-import { postEdit, validateGrid } from './builderUtils';
-import { PuzzleAction } from './commonActions';
+import { hasSelection, postEdit, validateGrid } from './builderUtils';
+import { PuzzleAction, isKeypressAction } from './commonActions';
 import {
   GridInterfaceState,
   closeRebus,
@@ -510,6 +515,59 @@ function _builderReducer(
   state: BuilderState,
   action: PuzzleAction
 ): BuilderState {
+  if (isKeypressAction(action)) {
+    const key = action.key;
+    if (key.k === KeyK.ShiftArrowRight) {
+      const { start, end } = hasSelection(state)
+        ? state.selection
+        : emptySelection(state.active);
+      return {
+        ...state,
+        wasEntryClick: false,
+        selection: {
+          start,
+          end: moveRight(state.grid, end),
+        },
+      };
+    } else if (key.k === KeyK.ShiftArrowLeft) {
+      const { start, end } = hasSelection(state)
+        ? state.selection
+        : emptySelection(state.active);
+      return {
+        ...state,
+        wasEntryClick: false,
+        selection: {
+          start,
+          end: moveLeft(state.grid, end),
+        },
+      };
+    } else if (key.k === KeyK.ShiftArrowUp) {
+      const { start, end } = hasSelection(state)
+        ? state.selection
+        : emptySelection(state.active);
+      return {
+        ...state,
+        wasEntryClick: false,
+        selection: {
+          start,
+          end: moveUp(state.grid, end),
+        },
+      };
+    } else if (key.k === KeyK.ShiftArrowDown) {
+      const { start, end } = hasSelection(state)
+        ? state.selection
+        : emptySelection(state.active);
+      return {
+        ...state,
+        wasEntryClick: false,
+        selection: {
+          start,
+          end: moveDown(state.grid, end),
+        },
+      };
+    }
+    return state;
+  }
   if (isStartSelectionAction(action)) {
     return {
       ...closeRebus(state),

--- a/app/reducers/commonActions.ts
+++ b/app/reducers/commonActions.ts
@@ -1,3 +1,15 @@
+import { Key } from '../lib/types';
+
 export interface PuzzleAction {
   type: string;
+}
+
+export interface KeypressAction extends PuzzleAction {
+  type: 'KEYPRESS';
+  key: Key;
+}
+export function isKeypressAction(
+  action: PuzzleAction
+): action is KeypressAction {
+  return action.type === 'KEYPRESS';
 }

--- a/app/reducers/gridReducer.ts
+++ b/app/reducers/gridReducer.ts
@@ -1,16 +1,11 @@
 import { cellIndex, clampInBounds, isInBounds, valAt } from '../lib/gridBase';
-import {
-  emptySelection,
-  forEachPosition,
-  getSelectionCells,
-} from '../lib/selection';
+import { forEachPosition, getSelectionCells } from '../lib/selection';
 import {
   ALLOWABLE_GRID_CHARS,
   BLOCK,
   CELL_DELIMITER,
   Direction,
   EMPTY,
-  Key,
   KeyK,
   PosAndDir,
   Position,
@@ -41,7 +36,7 @@ import {
   hasSelection,
   isBuilderState,
 } from './builderUtils';
-import type { PuzzleAction } from './commonActions';
+import { PuzzleAction, isKeypressAction } from './commonActions';
 import type { PuzzleState } from './puzzleReducer';
 import { isPuzzleState, postEdit as puzzlePostEdit } from './puzzleUtils';
 
@@ -55,14 +50,6 @@ export interface GridInterfaceState {
   rebusValue: string;
   downsOnly: boolean;
   isEditable(cellIndex: number): boolean;
-}
-
-export interface KeypressAction extends PuzzleAction {
-  type: 'KEYPRESS';
-  key: Key;
-}
-function isKeypressAction(action: PuzzleAction): action is KeypressAction {
-  return action.type === 'KEYPRESS';
 }
 
 export interface CopyAction extends PuzzleAction {
@@ -408,19 +395,7 @@ export function gridInterfaceReducer<T extends GridInterfaceState>(
         wasEntryClick: false,
         active: moveToPrevEntry(state.grid, state.active),
       };
-    } else if (key.k === KeyK.ShiftArrowRight && isBuilderState(state)) {
-      const { start, end } = hasSelection(state)
-        ? state.selection
-        : emptySelection(state.active);
-      return {
-        ...state,
-        wasEntryClick: false,
-        selection: {
-          start,
-          end: moveRight(state.grid, end),
-        },
-      };
-    } else if (key.k === KeyK.ArrowRight || key.k === KeyK.ShiftArrowRight) {
+    } else if (key.k === KeyK.ArrowRight) {
       state = clearSelection(state);
       return {
         ...state,
@@ -433,19 +408,7 @@ export function gridInterfaceReducer<T extends GridInterfaceState>(
           dir: Direction.Across,
         },
       };
-    } else if (key.k === KeyK.ShiftArrowLeft && isBuilderState(state)) {
-      const { start, end } = hasSelection(state)
-        ? state.selection
-        : emptySelection(state.active);
-      return {
-        ...state,
-        wasEntryClick: false,
-        selection: {
-          start,
-          end: moveLeft(state.grid, end),
-        },
-      };
-    } else if (key.k === KeyK.ArrowLeft || key.k === KeyK.ShiftArrowLeft) {
+    } else if (key.k === KeyK.ArrowLeft) {
       state = clearSelection(state);
       return {
         ...state,
@@ -458,19 +421,7 @@ export function gridInterfaceReducer<T extends GridInterfaceState>(
           dir: Direction.Across,
         },
       };
-    } else if (key.k === KeyK.ShiftArrowUp && isBuilderState(state)) {
-      const { start, end } = hasSelection(state)
-        ? state.selection
-        : emptySelection(state.active);
-      return {
-        ...state,
-        wasEntryClick: false,
-        selection: {
-          start,
-          end: moveUp(state.grid, end),
-        },
-      };
-    } else if (key.k === KeyK.ArrowUp || key.k === KeyK.ShiftArrowUp) {
+    } else if (key.k === KeyK.ArrowUp) {
       state = clearSelection(state);
       return {
         ...state,
@@ -483,19 +434,7 @@ export function gridInterfaceReducer<T extends GridInterfaceState>(
           dir: Direction.Down,
         },
       };
-    } else if (key.k === KeyK.ShiftArrowDown && isBuilderState(state)) {
-      const { start, end } = hasSelection(state)
-        ? state.selection
-        : emptySelection(state.active);
-      return {
-        ...state,
-        wasEntryClick: false,
-        selection: {
-          start,
-          end: moveDown(state.grid, end),
-        },
-      };
-    } else if (key.k === KeyK.ArrowDown || key.k === KeyK.ShiftArrowDown) {
+    } else if (key.k === KeyK.ArrowDown) {
       state = clearSelection(state);
       return {
         ...state,

--- a/app/reducers/puzzleReducer.ts
+++ b/app/reducers/puzzleReducer.ts
@@ -7,7 +7,8 @@ import {
   moveDown,
   moveLeft,
   moveRight,
-  moveToNextEntryInDirection,
+  moveToEntry,
+  moveToEntryInActiveDirection,
   moveUp,
   nextNonBlock,
 } from '../lib/viewableGrid';
@@ -151,8 +152,8 @@ export function puzzleReducer(
           state.grid,
           state.active,
           state.active.dir === Direction.Across
-            ? moveToNextEntryInDirection(state.grid, state.active)
-            : moveRight(state.grid, state.active),
+            ? moveToEntryInActiveDirection(state.grid, state.active)
+            : moveToEntry(state.grid, state.active, moveRight),
           state.wrongCells
         ),
       };
@@ -164,8 +165,8 @@ export function puzzleReducer(
           state.grid,
           state.active,
           state.active.dir === Direction.Across
-            ? moveToNextEntryInDirection(state.grid, state.active, true)
-            : moveLeft(state.grid, state.active),
+            ? moveToEntryInActiveDirection(state.grid, state.active, true)
+            : moveToEntry(state.grid, state.active, moveLeft),
           state.wrongCells
         ),
       };
@@ -177,8 +178,8 @@ export function puzzleReducer(
           state.grid,
           state.active,
           state.active.dir === Direction.Down
-            ? moveToNextEntryInDirection(state.grid, state.active, true)
-            : moveUp(state.grid, state.active),
+            ? moveToEntryInActiveDirection(state.grid, state.active, true)
+            : moveToEntry(state.grid, state.active, moveUp),
           state.wrongCells
         ),
       };
@@ -190,8 +191,8 @@ export function puzzleReducer(
           state.grid,
           state.active,
           state.active.dir === Direction.Down
-            ? moveToNextEntryInDirection(state.grid, state.active)
-            : moveDown(state.grid, state.active),
+            ? moveToEntryInActiveDirection(state.grid, state.active)
+            : moveToEntry(state.grid, state.active, moveDown),
           state.wrongCells
         ),
       };

--- a/app/reducers/puzzleReducer.ts
+++ b/app/reducers/puzzleReducer.ts
@@ -247,17 +247,17 @@ export function puzzleReducer(
     }
     const play = action.play;
     if (play === null) {
-    const downsOnly = action.prefs?.solveDownsOnly ?? false;
-    return {
-      ...state,
-      downsOnly,
-      active: {
-        ...state.active,
-        dir: downsOnly ? Direction.Down : state.active.dir,
-      },
-      prefs: action.prefs,
-      loadedPlayState: true,
-    };
+      const downsOnly = action.prefs?.solveDownsOnly ?? false;
+      return {
+        ...state,
+        downsOnly,
+        active: {
+          ...state.active,
+          dir: downsOnly ? Direction.Down : state.active.dir,
+        },
+        prefs: action.prefs,
+        loadedPlayState: true,
+      };
     }
     const downsOnly = play.do ?? false;
     return {


### PR DESCRIPTION
This PR adds shift + arrow key navigation to the puzzle view.

There are a few different ways this kind of navigation can work. I generally tried to follow what most other solvers seem to do, but am happy to make things work differently or add user preference settings, etc.! 

Here are the possibilities I considered, with the implementation I went with marked in bold:

1. For moving _with_ the active direction:
A. Move to the next/prev clue numerically (a lot of places seem to do this)
**B.** Move to the next clue over, spatially (I prefer this bc A is already covered by tab/enter)

2. For moving _perpendicular_ to the active direction:
A. Move to the next non-block square over
B. Move to the next non-block square over if a clue exists there (relevant for e.g. UK-style, where squares can be unchecked)
**C.** Move to the next clue over

3. When moving to a clue:
A. Move to the spatially relevant square (I might prefer this?)
**B.** Move to the first empty square of the clue
C. Move to the first square of the clue

Closes https://github.com/crosshare-org/crosshare/issues/148