### PR TITLE
Fix enumeration warnings

### DIFF
--- a/app/reducers/builderReducer.ts
+++ b/app/reducers/builderReducer.ts
@@ -24,6 +24,7 @@ import {
   moveUp,
 } from '../lib/viewableGrid';
 import {
+  forEachCluedEntry,
   getWarningStats,
   hasSelection,
   postEdit,
@@ -486,21 +487,10 @@ export function getClueProps(
   const dc: string[] = [];
   const dn: number[] = [];
 
-  const wordCounts: Record<string, number> = {};
-
-  sortedEntries.forEach((entryidx) => {
-    const e = entries[entryidx];
-    if (!e) {
-      return;
-    }
+  forEachCluedEntry(sortedEntries, entries, clues, (e, clueString) => {
     if (requireComplete && !e.completedWord) {
       throw new Error('Publish unfinished grid');
     }
-    const word = e.completedWord ?? '';
-    const clueArray = clues[word] ?? [];
-    const idx = wordCounts[word] ?? 0;
-    wordCounts[word] = idx + 1;
-    const clueString = clueArray[idx] ?? '';
 
     if (requireComplete && !clueString) {
       throw new Error('Bad clue for ' + e.completedWord);
@@ -822,14 +812,14 @@ function _builderReducer(
           .join(', ')})`
       );
     }
-    if (stats.missingEnums) {
+    if (stats.missingEnums && stats.missingEnums.size > 0) {
       warnings.push(
         `Some clues are missing enumerations: (${Array.from(stats.missingEnums)
           .sort()
           .join(', ')})`
       );
     }
-    if (stats.wrongEnums) {
+    if (stats.wrongEnums && stats.wrongEnums.size > 0) {
       warnings.push(
         `Some clues have enumerations that don't match the answer length: (${Array.from(
           stats.wrongEnums


### PR DESCRIPTION
Seems like a couple of things might be wrong with the enumeration warnings:
- They are considering clues written for entries that are no longer in the grid
- They show up even when there are no warnings to show (missing a set size check)

In order to address the first problem, I tried to centralize the logic that decides what clues actually get included in the puzzle, so that the enumeration warnings can use it too. I think it will be useful in https://github.com/crosshare-org/crosshare/pull/507 as well, and it's possible it could be shared by the "missing clues" publishing error.

However, I'd totally understand if the priority is just to get the warnings fixed and not risk any modifications to the (rather critical) publishing code!