### PR TITLE
Switch direction on mobile by tapping in the clue box

### DIFF
--- a/app/components/ClueList.module.scss
+++ b/app/components/ClueList.module.scss
@@ -6,15 +6,10 @@
   display: none;
 
   width: 100%;
-  height: 100%;
 
   list-style-type: none;
 
   background-color: var(--bg);
-}
-
-.item > div {
-  height: 100%;
 }
 
 .item[data-active='true'],
@@ -45,7 +40,6 @@
   align-items: center;
 
   width: 100%;
-  height: 100%;
   border-left: 1em solid transparent;
 }
 
@@ -134,11 +128,25 @@
   scrollbar-width: none;
   overflow-y: scroll;
   flex: 1;
-  max-height: 100%;
 }
 
-.list > ol {
-  height: 100%;
+/* stylelint-disable-next-line media-query-no-invalid */
+@media not ($small-and-up) {
+  .list > ol {
+    height: 100%;
+  }
+
+  .item[data-show-entry='false'] {
+    height: 100%;
+
+    > div {
+      height: 100%;
+    }
+
+    .outer {
+      height: 100%;
+    }
+  }
 }
 
 /* stylelint-disable-next-line media-query-no-invalid */

--- a/app/components/ClueList.module.scss
+++ b/app/components/ClueList.module.scss
@@ -6,10 +6,15 @@
   display: none;
 
   width: 100%;
+  height: 100%;
 
   list-style-type: none;
 
   background-color: var(--bg);
+}
+
+.item > div {
+  height: 100%;
 }
 
 .item[data-active='true'],
@@ -40,6 +45,7 @@
   align-items: center;
 
   width: 100%;
+  height: 100%;
   border-left: 1em solid transparent;
 }
 
@@ -64,8 +70,13 @@
 }
 
 .clueText {
+  display: flex;
   flex: 1 1 auto;
+  flex-direction: column;
+  justify-content: space-around;
+
   height: 100%;
+
   color: var(--text);
 }
 
@@ -100,7 +111,7 @@
 .listWrapper {
   position: relative;
   display: flex;
-  align-items: center;
+  align-items: stretch;
   height: 100% !important;
 }
 
@@ -122,7 +133,12 @@
 .list {
   scrollbar-width: none;
   overflow-y: scroll;
+  flex: 1;
   max-height: 100%;
+}
+
+.list > ol {
+  height: 100%;
 }
 
 /* stylelint-disable-next-line media-query-no-invalid */


### PR DESCRIPTION
This is a fix to the UI when solving a puzzle on a phone. When you tapped the selected clue to switch directions, you previously needed to tap on the actual text of the clue, not the box containing the clue. With this fix, you can tap the containing box to change directions, which gives you a large click target whose size is not dependent on the length of the clue.

<img  width="270" alt="A screenshot of the Crosshare solving interface on mobile. You used to need to click the text of the clue; now you can click the box containing the clue." src="https://github.com/user-attachments/assets/adb1ad66-7ff9-4c18-acde-5b17b2a93140" />

