### PR TITLE
Update notification titles when a puzzle is renamed

### DIFF
--- a/app/__tests__/puzzleUpdate.test.ts
+++ b/app/__tests__/puzzleUpdate.test.ts
@@ -1458,3 +1458,84 @@ test('should update indexes when a private until puzzle is marked private', asyn
     overrideToFirestore(null);
   });
 });
+
+test('should update puzzle title on existing notifications when title changes', async () => {
+  await testEnv.clearFirestore();
+
+  await testEnv.withSecurityRulesDisabled(async (adminApp) => {
+    const firestore = adminApp.firestore();
+    overrideFirestore(firestore as unknown as FirebaseFirestore.Firestore);
+    overrideToFirestore(convertTimestamps);
+
+    const puzzleWithComments = {
+      ...basePuzzle,
+      cs: [getComment({ a: 'dummy-author-id' })],
+    };
+    const puzzleWithComments2 = {
+      ...basePuzzle,
+      cs: [getComment({ a: 'dummy-author-id', i: 'randomCommentId' })],
+    };
+
+    await firestore
+      .collection('c')
+      .withConverter(converter)
+      .doc(toDeleteId)
+      .set(puzzleWithComments);
+    await firestore
+      .collection('c')
+      .withConverter(converter)
+      .doc(toKeepId)
+      .set(puzzleWithComments2);
+
+    await handlePuzzleUpdate(basePuzzle, puzzleWithComments, toDeleteId);
+    await handlePuzzleUpdate(basePuzzle, puzzleWithComments2, toKeepId);
+
+    await handlePuzzleUpdate(
+      puzzleWithComments,
+      { ...puzzleWithComments, t: 'A new title' },
+      toDeleteId
+    );
+
+    expect(
+      await firestore
+        .collection('n')
+        .get()
+        .then((r) =>
+          r.docs
+            .map((d) => d.data())
+            .map((d) => {
+              delete d.t;
+              return d;
+            })
+            .sort((a, b) => a.id.localeCompare(b.id))
+        )
+    ).toMatchInlineSnapshot(`
+      [
+        {
+          "c": "LwgoVx0BAskM4wVJyoLj",
+          "cn": "Mike D",
+          "e": false,
+          "id": "fSEwJorvqOMK5UhNMHa4mu48izl1-comment-LwgoVx0BAskM4wVJyoLj",
+          "k": "comment",
+          "p": "puzzletodelete",
+          "pn": "A new title",
+          "r": false,
+          "u": "fSEwJorvqOMK5UhNMHa4mu48izl1",
+        },
+        {
+          "c": "randomCommentId",
+          "cn": "Mike D",
+          "e": false,
+          "id": "fSEwJorvqOMK5UhNMHa4mu48izl1-comment-randomCommentId",
+          "k": "comment",
+          "p": "puzzletokeep",
+          "pn": "Raises, as young",
+          "r": false,
+          "u": "fSEwJorvqOMK5UhNMHa4mu48izl1",
+        },
+      ]
+    `);
+    overrideFirestore(null);
+    overrideToFirestore(null);
+  });
+});

--- a/app/lib/puzzleUpdate.ts
+++ b/app/lib/puzzleUpdate.ts
@@ -238,6 +238,16 @@ export async function handlePuzzleUpdate(
         });
       }
     }
+
+    // title changed: keep existing notification puzzle names in sync
+    if (after.t !== before.t) {
+      await updateNotifications(puzzleId, (n) => {
+        if (n.pn !== after.t) {
+          return { pn: after.t };
+        }
+        return null;
+      });
+    }
   }
 
   const notifications = await notificationsForPuzzleChange(


### PR DESCRIPTION
This is the same change as #578, with the commit history squashed to a **single commit** as requested in review (the original PR had 10 commits that deleted/recreated the puzzleUpdate test file).

When you rename a puzzle, the puzzle document gets the new title but existing notifications still show the old one. They store a copy of the name as `pn`, and nothing was writing that back on title edits.

This updates those records in the puzzleUpdate trigger, same approach we already use when privateUntil changes. Added a test that renames one puzzle and checks only that puzzle’s notifications pick up the new title.

Fixes #577