### PR TITLE
Display puzzle title on puzzle page outside the pause modal

### DIFF
--- a/app/components/Puzzle.module.scss
+++ b/app/components/Puzzle.module.scss
@@ -87,6 +87,19 @@
   vertical-align: middle;
 }
 
+.puzzleTitle {
+  flex: none;
+  overflow: hidden;
+
+  padding: 0.25em 1em;
+
+  font-size: 1em;
+  font-weight: bold;
+  white-space: nowrap;
+  text-align: center;
+  text-overflow: ellipsis;
+}
+
 .puzzleWrap {
   scrollbar-width: none;
   position: relative;

--- a/app/components/Puzzle.module.scss
+++ b/app/components/Puzzle.module.scss
@@ -87,19 +87,6 @@
   vertical-align: middle;
 }
 
-.puzzleTitle {
-  flex: none;
-  overflow: hidden;
-
-  padding: 0.25em 1em;
-
-  font-size: 1em;
-  font-weight: bold;
-  white-space: nowrap;
-  text-align: center;
-  text-overflow: ellipsis;
-}
-
 .puzzleWrap {
   scrollbar-width: none;
   position: relative;

--- a/app/components/Puzzle.tsx
+++ b/app/components/Puzzle.tsx
@@ -1273,7 +1273,7 @@ export const Puzzle = ({
               ) : (
                 ''
               )}
-              <TopBar title={puzzle.title}>
+              <TopBar title={puzzle.title} showTitle={!isSlate && (state.currentTimeWindowStart !== 0 || state.success)}>
                 {!loadingPlayState ? (
                   !state.success ? (
                     <>
@@ -1441,12 +1441,6 @@ export const Puzzle = ({
                   loadingPlayState={loadingPlayState || !state.loadedPlayState}
                 />
               )
-            ) : (
-              ''
-            )}
-            {!isSlate &&
-            (state.currentTimeWindowStart !== 0 || state.success) ? (
-              <div className={styles.puzzleTitle}>{puzzle.title}</div>
             ) : (
               ''
             )}

--- a/app/components/Puzzle.tsx
+++ b/app/components/Puzzle.tsx
@@ -1444,6 +1444,12 @@ export const Puzzle = ({
             ) : (
               ''
             )}
+            {!isSlate &&
+            (state.currentTimeWindowStart !== 0 || state.success) ? (
+              <div className={styles.puzzleTitle}>{puzzle.title}</div>
+            ) : (
+              ''
+            )}
             <div tabIndex={0} role={'textbox'} className={styles.puzzleWrap}>
               {puzzleView}
             </div>

--- a/app/components/TopBar.tsx
+++ b/app/components/TopBar.tsx
@@ -240,9 +240,11 @@ const TopBarLinkA = (props: TopBarLinkAProps) => {
 export const TopBar = ({
   children,
   title,
+  showTitle,
 }: {
   children?: ReactNode;
   title?: string;
+  showTitle?: boolean;
 }) => {
   const { notifications } = useContext(AuthContext);
   const { isEmbed } = useContext(EmbedContext);
@@ -324,6 +326,13 @@ export const TopBar = ({
                 />
                 <span className={styles.logoText}>CROSSHARE</span>
               </Link>
+            )}
+            {showTitle && !isEmbed && !isSlate ? (
+              <div title={title} className={styles.embedTitle}>
+                {title}
+              </div>
+            ) : (
+              ''
             )}
             <>{children}</>
           </div>


### PR DESCRIPTION
Fixes #573

The puzzle title was only visible inside the pause/begin overlay, making it invisible while solving. This matters for puzzles where the title is a hint (e.g. 'Distant Lands').

## Changes
- Added a puzzleTitle bar below the TopBar showing puzzle.title while the puzzle is active or solved
- Uses white-space:nowrap + text-overflow:ellipsis to truncate long titles without multiline wrapping (as suggested in the issue)
- Hidden when the pause overlay is open (title is already shown there)
- Hidden in Slate embed mode (SlateHeader already handles that case)