### PR TITLE
Add enclosure for puz files in RSS feed

### DIFF
--- a/app/pages/api/feed/[username].ts
+++ b/app/pages/api/feed/[username].ts
@@ -61,6 +61,10 @@ export default async function constructorFeed(
       id: link,
       link: link,
       date: new Date(p.isPrivateUntil ?? p.publishTime),
+      enclosure: {
+        url: `https://crosshare.org/api/puz/${p.id}`,
+        type: "application/x-crossword"
+      },
       description: p.blogPost
         ? toHtml(
             markdownToHast({

--- a/app/pages/api/feed/[username].ts
+++ b/app/pages/api/feed/[username].ts
@@ -63,7 +63,7 @@ export default async function constructorFeed(
       date: new Date(p.isPrivateUntil ?? p.publishTime),
       enclosure: {
         url: `https://crosshare.org/api/puz/${p.id}`,
-        type: "application/x-crossword"
+        type: 'application/x-crossword',
       },
       description: p.blogPost
         ? toHtml(


### PR DESCRIPTION
This PR allows RSS clients to discover the .puz file directly from the feed for each puzzle item. 

For example, I'm developing a crossword application where users will input a subscribable RSS feed, and puzzles with published `.puz` files as enclosures will be surfaced as immediately playable.